### PR TITLE
Convert to oomphinc/composer-installers-extender

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "source": "https://github.com/furf/jquery-ui-touch-punch"
   },
   "require": {
-    "robloach/component-installer": "*"
+    "oomphinc/composer-installers-extender": "*"
   },
   "extra":{
     "component": {


### PR DESCRIPTION
robloach/component-installer is abandoned, convert to oomphinc/composer-installers-extender